### PR TITLE
Point to favicon.ico on root path

### DIFF
--- a/lib/lax_web/components/layouts/root.html.heex
+++ b/lib/lax_web/components/layouts/root.html.heex
@@ -7,7 +7,7 @@
     <.live_title suffix=" · Lax">
       <%= assigns[:page_title] || "Welcome" %>
     </.live_title>
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="/favicon.ico" />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>


### PR DESCRIPTION
Please let me know if PRs are alright, this repo is cool and figured I'd fix a few quick things I found while spinning it up!

----

This PR fixes the following error, where upon switching channels, an error is generated due to `favicon.ico` being fetched from a relative path:

![Screenshot 2024-06-10 at 8 28 26 PM](https://github.com/jtormey/lax/assets/7387903/f889bfba-a735-428f-b266-3cba2af4259b)

The problem is fixed by specifying that the path should always be at the root of the application.