### PR TITLE
Add profile sidebar for iOS

### DIFF
--- a/lib/lax_web/live/chat_live.swiftui.ex
+++ b/lib/lax_web/live/chat_live.swiftui.ex
@@ -9,6 +9,16 @@ defmodule LaxWeb.ChatLive.SwiftUI do
   import LaxWeb.DirectMessageLive.Components.SwiftUI
   import LaxWeb.UserLive.Components.SwiftUI
 
+  def render(%{ user_profile: user_profile } = assigns, _interface) when not is_nil(user_profile) do
+    ~LVN"""
+    <.user_profile_sidebar
+      user={@user_profile}
+      online_fun={&LaxWeb.Presence.Live.online?(assigns, &1)}
+      current_user={@current_user}
+    />
+    """
+  end
+
   def render(%{live_action: :chat} = assigns, _interface) do
     ~LVN"""
     <.header>
@@ -84,6 +94,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
         :for={message <- Enum.reverse(group_messages(@chat.messages))}
         message_id={message.id}
         user={message.sent_by_user}
+        user_detail_patch={~p"/chat/#{@chat.current_channel}?profile=#{message.sent_by_user}"}
         online={LaxWeb.Presence.Live.online?(assigns, message.sent_by_user)}
         time={Message.show_time(message, @current_user && @current_user.time_zone)}
         text={message.text}

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -222,7 +222,7 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
         <VStack alignment="leading">
           <HStack>
             <.link navigate={@user_detail_patch}>
-              <Text style="font(.headline);">
+              <Text style="font(.headline); foregroundStyle(.primary);">
                 <%= @user.username %>
               </Text>
             </.link>

--- a/lib/lax_web/live/user_live/user_components.swiftui.ex
+++ b/lib/lax_web/live/user_live/user_components.swiftui.ex
@@ -2,7 +2,7 @@ defmodule LaxWeb.UserLive.Components.SwiftUI do
   use LiveViewNative.Component
 
   attr :user, Lax.Users.User, required: true
-  attr :size, :atom, values: [:xs, :md]
+  attr :size, :atom, values: [:xs, :md, :xl]
   attr :online, :boolean, default: nil
 
   def user_profile(%{size: :xs} = assigns) do
@@ -31,8 +31,21 @@ defmodule LaxWeb.UserLive.Components.SwiftUI do
     """
   end
 
+  def user_profile(%{size: :xl} = assigns) do
+    ~LVN"""
+    <ZStack alignment="bottomTrailing" style="aspectRatio(1, contentMode: .fit);">
+      <RoundedRectangle
+        cornerRadius={16}
+        style='fill(attr("display_color"));'
+        display_color={@user.display_color}
+      />
+      <.online_indicator :if={@online != nil} online={@online} size={@size} />
+    </ZStack>
+    """
+  end
+
   attr :online, :boolean, required: true
-  attr :size, :atom, values: [:xs, :md]
+  attr :size, :atom, values: [:xs, :md, :xl]
 
   defp online_indicator(%{size: :xs} = assigns) do
     ~LVN"""
@@ -50,6 +63,16 @@ defmodule LaxWeb.UserLive.Components.SwiftUI do
         <Circle :if={@online == true} style='fill(.green); frame(width: 10, height: 10); overlay(:border); padding(-1);' />
         <Circle :if={@online == false} style='fill(.gray); frame(width: 10, height: 10); overlay(:border); padding(-1);' />
         <Circle style='stroke(.background, lineWidth: 2);' />
+      </ZStack>
+    """
+  end
+
+  defp online_indicator(%{size: :xl} = assigns) do
+    ~LVN"""
+      <ZStack style='frame(width: 32, height: 32);'>
+        <Circle :if={@online == true} style='fill(.green); frame(width: 32, height: 32); overlay(:border); padding(-1);' />
+        <Circle :if={@online == false} style='fill(.gray); frame(width: 32, height: 32); overlay(:border); padding(-1);' />
+        <Circle style='stroke(.background, lineWidth: 4);' />
       </ZStack>
     """
   end


### PR DESCRIPTION
This adds a version of the profile sidebar UI to the iOS client.

It is displayed as a separate page on iOS. It could be expanded in a future PR to use an `inspector` modifier on iPad for a right sidebar layout.

<img src="https://github.com/user-attachments/assets/ebd7d5ff-598f-4a48-88c7-de0a3369847f" width="200" />
<img src="https://github.com/user-attachments/assets/64002d0b-6805-48d2-af6c-361220325af2" width="200" />
