### PR TITLE
Refine SwiftUI message bar UI

### DIFF
--- a/lib/lax_web/components/layouts_swiftui/root.swiftui.neex
+++ b/lib/lax_web/components/layouts_swiftui/root.swiftui.neex
@@ -1,5 +1,5 @@
 <.csrf_token />
 <Style url={~p"/assets/app.swiftui.styles"} />
-<NavigationStack>
+<NavigationStack style="tint(Color(.sRGB, red: 0.26, green: 0.58, blue: 0.42))">
   <%= @inner_content %>
 </NavigationStack>

--- a/lib/lax_web/live/chat_live.swiftui.ex
+++ b/lib/lax_web/live/chat_live.swiftui.ex
@@ -95,7 +95,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
           :if={@current_user}
           chat={@chat}
           form={@chat_form}
-          phx-validate="swiftui_validate"
+          phx-change="swiftui_validate"
           phx-submit="swiftui_submit"
         />
         <.chat_signed_out_notice :if={!@current_user} />

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -152,7 +152,7 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
 
   def chat(assigns) do
     ~LVN"""
-    <ScrollView style="defaultScrollAnchor(.bottom); safeAreaInset(edge: .bottom, content: :bottom_bar);">
+    <ScrollView style="scrollDismissesKeyboard(.immediately); defaultScrollAnchor(.bottom); safeAreaInset(edge: .bottom, content: :bottom_bar);">
       <VStack
         alignment="leading"
         style='frame(maxWidth: .infinity, alignment: .leading); animation(.default, value: attr("animation_key"));'
@@ -160,9 +160,10 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
       >
         <%= render_slot(@inner_block) %>
       </VStack>
-      <Group template={:bottom_bar} style="background(.bar);">
+      <VStack spacing="0" template={:bottom_bar} style="background(.bar);">
+        <Divider />
         <%= render_slot(@bottom_bar) %>
-      </Group>
+      </VStack>
     </ScrollView>
     """
   end
@@ -242,17 +243,23 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
 
   def chat_form(assigns) do
     ~LVN"""
-    <HStack style="padding();">
+    <HStack style="padding(.leading); padding(.vertical, 8); padding(.trailing, 8);">
       <.form {@rest} for={@form}>
         <.input
-          field={@form[:text]}
+          field={Map.put(@form[:text], :errors, [])}
           placeholder={ChannelChatComponent.placeholder(@chat.current_channel)}
         />
         <LiveSubmitButton
-          style="buttonStyle(.borderedProminent);"
+          style={[
+            "buttonStyle(.borderedProminent)",
+            "buttonBorderShape(.circle)",
+            "controlSize(.small)",
+            ~s[disabled(attr("disabled"))]
+          ]}
           after-submit="clear"
+          disabled={not @form.source.valid?}
         >
-          <Image systemName="paperplane" style="padding(4);" />
+          <Image systemName="paperplane.fill" style="padding(4);" />
         </LiveSubmitButton>
       </.form>
     </HStack>


### PR DESCRIPTION
This makes a few changes to the message bar on iOS:

1. Adds a `Divider` to provide a visual separation from the messages
2. Makes the send button a circle to match Slack's iOS app
3. Disables the send button until the message passes validation.
4. Enables scroll to dismiss keyboard.
5. Sets the app tint color to match the website's green color.

https://github.com/user-attachments/assets/a19a1b68-c487-4423-b18a-57d40def459b

