### PR TITLE
New DM form for iOS

### DIFF
--- a/lib/lax_web/components/core_components.swiftui.ex
+++ b/lib/lax_web/components/core_components.swiftui.ex
@@ -260,7 +260,9 @@ defmodule LaxWeb.CoreComponents.SwiftUI do
 
   slot :inner_block, required: true
   slot :subtitle
-  slot :actions
+  slot :actions do
+    attr :placement, :string
+  end
 
   def header(assigns) do
     ~LVN"""
@@ -274,8 +276,12 @@ defmodule LaxWeb.CoreComponents.SwiftUI do
       <Text :if={@subtitle != []} template="subtitle">
         <%= render_slot(@subtitle) %>
       </Text>
-      <ToolbarItemGroup template="toolbar">
-        <%= render_slot(@actions) %>
+      <ToolbarItemGroup
+        :for={action <- @actions}
+        template="toolbar"
+        placement={action.placement}
+      >
+        <%= render_slot(action) %>
       </ToolbarItemGroup>
     </VStack>
     """

--- a/lib/lax_web/components/core_components.swiftui.ex
+++ b/lib/lax_web/components/core_components.swiftui.ex
@@ -283,6 +283,7 @@ defmodule LaxWeb.CoreComponents.SwiftUI do
       >
         <%= render_slot(action) %>
       </ToolbarItemGroup>
+      <ToolbarItemGroup template="toolbar" :if={Enum.empty?(@actions)} />
     </VStack>
     """
   end

--- a/lib/lax_web/live/chat_live.swiftui.ex
+++ b/lib/lax_web/live/chat_live.swiftui.ex
@@ -23,7 +23,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
     ~LVN"""
     <.header>
       Workspace
-      <:actions>
+      <:actions placement="primaryAction">
         <.link :if={!@current_user} navigate={~p"/users/register"} class="font-weight-semibold fg-tint">
           Sign in or register
         </.link>
@@ -33,6 +33,13 @@ defmodule LaxWeb.ChatLive.SwiftUI do
           </:option>
           <.user_profile :if={@current_user} user={@current_user} size={:md} online />
         </.user_options>
+      </:actions>
+      <:actions placement="navigation">
+        <Group>
+          <.link :if={@current_user != nil and @swiftui_tab == :direct_messages} navigate={~p"/direct-messages"}>
+            <Image systemName="plus" />
+          </.link>
+        </Group>
       </:actions>
     </.header>
 
@@ -65,7 +72,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
         </.workspace_list>
       </.tab>
 
-      <.tab tag={:direct_messages} name="DMs" icon_system_name="message">
+      <.tab tag={:direct_messages} name="DMs" icon_system_name="bubble.left.and.text.bubble.right">
         <Text :if={!@current_user} style="font(.subheadline);">
           Sign in to use the direct messaging feature.
         </Text>

--- a/lib/lax_web/live/chat_live.swiftui.ex
+++ b/lib/lax_web/live/chat_live.swiftui.ex
@@ -36,7 +36,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
       </:actions>
       <:actions placement="navigation">
         <Group>
-          <.link :if={@current_user != nil and @swiftui_tab == :direct_messages} navigate={~p"/direct-messages"}>
+          <.link :if={@current_user != nil and @swiftui_tab == :direct_messages} navigate={~p"/new-direct-message"}>
             <Image systemName="plus" />
           </.link>
         </Group>
@@ -111,7 +111,7 @@ defmodule LaxWeb.ChatLive.SwiftUI do
       <:bottom_bar>
         <.chat_form
           :if={@current_user}
-          chat={@chat}
+          placeholder={LaxWeb.ChatLive.ChannelChatComponent.placeholder(@chat.current_channel)}
           form={@chat_form}
           phx-change="swiftui_validate"
           phx-submit="swiftui_submit"

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -240,9 +240,9 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
     """
   end
 
-  attr :chat, Lax.Chat, required: true
   attr :form, Phoenix.HTML.Form, required: true
-  attr :rest, :global
+  attr :placeholder, :string, required: true
+  attr :rest, :global, include: ~w(phx-change phx-submit phx-target)
 
   def chat_form(assigns) do
     ~LVN"""
@@ -250,7 +250,7 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
       <.form {@rest} for={@form}>
         <.input
           field={Map.put(@form[:text], :errors, [])}
-          placeholder={ChannelChatComponent.placeholder(@chat.current_channel)}
+          placeholder={@placeholder}
         />
         <LiveSubmitButton
           style={[

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -112,7 +112,6 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
   def direct_message_item(assigns) do
     ~LVN"""
     <.link {@rest}>
-      <% dbg @unread_count %>
       <LabeledContent style='badge(attr("count"));' count={@unread_count}>
         <HStack template="label">
           <.user_profile user={hd(@users)} online={@online_fun.(hd(@users))} size={:xs} />
@@ -318,7 +317,7 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
 
         <.link
           :if={@current_user}
-          navigate={~p"/direct-messages?to_user=#{@user}"}
+          navigate={~p"/new-direct-message?to_user=#{@user}"}
           style='buttonStyle(.borderedProminent); controlSize(.large); padding(.vertical);'
         >
           <Text style="frame(maxWidth: .infinity);">Direct message</Text>

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -112,16 +112,14 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
   def direct_message_item(assigns) do
     ~LVN"""
     <.link {@rest}>
-      <LabeledContent style="badge(:badge)">
+      <% dbg @unread_count %>
+      <LabeledContent style='badge(attr("count"));' count={@unread_count}>
         <HStack template="label">
           <.user_profile user={hd(@users)} online={@online_fun.(hd(@users))} size={:xs} />
           <Text>
             <%= Enum.map_join(@users, ", ", & &1.username) %>
           </Text>
         </HStack>
-        <Text :if={@active} template={:badge}>
-          <%= @unread_count %>
-        </Text>
       </LabeledContent>
     </.link>
     """

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -7,8 +7,6 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
   import LaxWeb.CoreComponents.SwiftUI
   import LaxWeb.UserLive.Components.SwiftUI
 
-  alias LaxWeb.ChatLive.ChannelChatComponent
-
   attr :rest, :global, include: ~w(phx-change selection)
   slot :inner_block, required: true
 
@@ -284,7 +282,6 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
 
   attr :user, Lax.Users.User, required: true
   attr :online_fun, :any, required: true
-  attr :on_cancel, :string, required: true
   attr :current_user, Lax.Users.User
 
   def user_profile_sidebar(assigns) do

--- a/lib/lax_web/live/chat_live/chat_components.swiftui.ex
+++ b/lib/lax_web/live/chat_live/chat_components.swiftui.ex
@@ -228,11 +228,11 @@ defmodule LaxWeb.ChatLive.Components.SwiftUI do
               </Text>
             </.link>
             <Spacer />
-            <Text style="font(.caption2); padding(.top, 4);">
+            <Text style="font(.caption2); foregroundStyle(.secondary); padding(.top, 4);">
               <%= @time %>
             </Text>
           </HStack>
-          <Text style="font(.body);" markdown={@text} />
+          <Text style="font(.body); textSelection(.enabled);" markdown={@text} />
         </VStack>
         <Spacer />
       </HStack>

--- a/lib/lax_web/live/direct_message_live.ex
+++ b/lib/lax_web/live/direct_message_live.ex
@@ -61,13 +61,17 @@ defmodule LaxWeb.DirectMessageLive do
 
   def render_action(%{live_action: :new} = assigns) do
     ~H"""
-    <.live_component
-      id="new_direct_message"
-      module={__MODULE__.NewDirectMessageComponent}
-      current_user={@current_user}
-      tracked_users={@tracked_users}
-      initial_user_ids={@initial_user_ids}
-    />
+    <%=
+      live_render(
+        @socket,
+        __MODULE__.NewDirectMessageLive,
+        id: "new_direct_message",
+        session: %{
+          "initial_user_ids" => @initial_user_ids
+        },
+        container: {:div, class: "flex flex-1 flex-col"}
+      )
+    %>
     """
   end
 

--- a/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
@@ -9,13 +9,10 @@ defmodule LaxWeb.DirectMessageLive.Components.SwiftUI do
 
   def direct_message_list(assigns) do
     ~LVN"""
-    <ScrollView style="toolbarTitleMenu(content: :toolbar);">
+    <ScrollView>
       <VStack alignment="leading">
         <%= render_slot(@inner_block) %>
       </VStack>
-      <Button template="toolbar">
-        <Image systemName="plus" />
-      </Button>
     </ScrollView>
     """
   end

--- a/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
@@ -2,6 +2,7 @@ defmodule LaxWeb.DirectMessageLive.Components.SwiftUI do
   use LiveViewNative.Component
 
   import LaxWeb.UserLive.Components.SwiftUI
+  import LiveViewNative.SwiftUI.Component
 
   alias Lax.Messages.Message
 
@@ -9,11 +10,9 @@ defmodule LaxWeb.DirectMessageLive.Components.SwiftUI do
 
   def direct_message_list(assigns) do
     ~LVN"""
-    <ScrollView>
-      <VStack alignment="leading">
-        <%= render_slot(@inner_block) %>
-      </VStack>
-    </ScrollView>
+    <List style="listStyle(.plain);">
+      <%= render_slot(@inner_block) %>
+    </List>
     """
   end
 
@@ -26,24 +25,25 @@ defmodule LaxWeb.DirectMessageLive.Components.SwiftUI do
 
   def direct_message_item_row(assigns) do
     ~LVN"""
-    <HStack alignment="top" style="padding(); background(.background);" phx-click="swiftui_navigate" phx-value-to={@navigate}>
-      <.user_profile user={hd(@users)} online={@online_fun.(hd(@users))} size={:md} />
-      <VStack alignment="leading">
-        <HStack style="padding(.bottom, 1);">
-          <Text style="font(.headline);">
-            <%= Enum.map_join(@users, ", ", & &1.username) %>
+    <.link navigate={@navigate} style="foregroundStyle(.primary);">
+      <HStack alignment="top">
+        <.user_profile user={hd(@users)} online={@online_fun.(hd(@users))} size={:md} />
+        <VStack alignment="leading">
+          <HStack style="padding(.bottom, 1);">
+            <Text style="font(.headline);">
+              <%= Enum.map_join(@users, ", ", & &1.username) %>
+            </Text>
+            <Spacer />
+            <Text style="font(.footnote);">
+              <%= Message.show_time(@latest_message, @current_user && @current_user.time_zone) %>
+            </Text>
+          </HStack>
+          <Text style="font(.subheadline);">
+            <%= @latest_message.sent_by_user.username%>: <%= @latest_message.text %>
           </Text>
-          <Spacer />
-          <Text style="font(.footnote);">
-            <%= Message.show_time(@latest_message, @current_user && @current_user.time_zone) %>
-          </Text>
-        </HStack>
-        <Text style="font(.subheadline);">
-          <%= @latest_message.sent_by_user.username%>: <%= @latest_message.text %>
-        </Text>
-      </VStack>
-    </HStack>
-    <Divider />
+        </VStack>
+      </HStack>
+    </.link>
     """
   end
 end

--- a/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/direct_message_components.swiftui.ex
@@ -9,10 +9,13 @@ defmodule LaxWeb.DirectMessageLive.Components.SwiftUI do
 
   def direct_message_list(assigns) do
     ~LVN"""
-    <ScrollView>
+    <ScrollView style="toolbarTitleMenu(content: :toolbar);">
       <VStack alignment="leading">
         <%= render_slot(@inner_block) %>
       </VStack>
+      <Button template="toolbar">
+        <Image systemName="plus" />
+      </Button>
     </ScrollView>
     """
   end

--- a/lib/lax_web/live/direct_message_live/new_direct_message_live.ex
+++ b/lib/lax_web/live/direct_message_live/new_direct_message_live.ex
@@ -16,7 +16,6 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive do
         New message
       </.header>
     </div>
-
     <div class="flex-1 relative overflow-y-scroll no-scrollbar px-4">
       <div class="absolute inset-0">
         <div class="flex-1 mx-auto max-w-sm py-16">
@@ -61,6 +60,10 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive do
     """
   end
 
+  def mount(%{ "to_user" => to_user }, session, socket) do
+    mount(%{}, Map.put(session, "initial_user_ids", [to_user]), socket)
+  end
+
   def mount(_params, session, socket) do
     current_user = if user_token = session["user_token"] do
       Users.get_user_by_session_token(user_token)
@@ -75,17 +78,6 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive do
       |> assign(:filter, "")
       |> assign(:filtered_users, all_users)
       |> handle_form()}
-  end
-
-  def update(assigns, socket) do
-    initial_user_ids = MapSet.new(assigns[:initial_user_ids] || [])
-
-    {:ok,
-     socket
-     |> assign(assigns)
-     |> assign(:selected_user_ids, initial_user_ids)
-     |> assign(:users, Users.list_other_users(assigns.current_user))
-     |> handle_form()}
   end
 
   def handle_event("add", %{"id" => user_id}, socket) do

--- a/lib/lax_web/live/direct_message_live/new_direct_message_live.ex
+++ b/lib/lax_web/live/direct_message_live/new_direct_message_live.ex
@@ -64,7 +64,7 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive do
     mount(%{}, Map.put(session, "initial_user_ids", [to_user]), socket)
   end
 
-  def mount(_params, session, socket) do
+  def mount(params, session, socket) when params == :not_mounted_at_router or socket.assigns._format == "swiftui" do
     current_user = if user_token = session["user_token"] do
       Users.get_user_by_session_token(user_token)
     end
@@ -78,6 +78,10 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive do
       |> assign(:filter, "")
       |> assign(:filtered_users, all_users)
       |> handle_form()}
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, redirect(socket, to: ~p"/direct-messages")}
   end
 
   def handle_event("add", %{"id" => user_id}, socket) do

--- a/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
@@ -1,7 +1,6 @@
 defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
   use LaxNative, [:render_component, format: :swiftui]
 
-  import LaxWeb.DirectMessageLive.Components.SwiftUI
   import LaxWeb.UserLive.Components.SwiftUI
   import LaxWeb.ChatLive.Components.SwiftUI
 
@@ -11,6 +10,7 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
       style={[
         ~s[searchable(text: attr("filter"), placement: .navigationBarDrawer(displayMode: .always), prompt: "Add users")],
         "safeAreaInset(edge: .bottom, content: :chat_form)",
+        "safeAreaInset(edge: .top, content: :group)",
         ~s[navigationTitle("New Message")]
       ]}
       filter={@filter}
@@ -23,45 +23,23 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
         ]}
         selected_user_ids={Enum.into(@selected_user_ids, [])}
       >
-        <Section>
-          <Text template="header">Group</Text>
-          <Button
-            :for={user <- Enum.map(@selected_user_ids, fn id -> Enum.find(@users, &(&1.id == id)) end)}
-            phx-click="remove"
-            phx-value-id={user.id}
-          >
-            <HStack>
-              <.user_profile
-                user={user}
-                online={LaxWeb.Presence.Live.online?(assigns, user)}
-                size={:md}
-              />
-              <Text><%= user.username %></Text>
-              <Spacer />
-              <Image systemName="minus" style="foregroundStyle(.tint);" />
-            </HStack>
-          </Button>
-        </Section>
-        <Section>
-          <Text template="header">More Users</Text>
-          <Button
-            :for={user <- @filtered_users}
-            :if={user.id not in @selected_user_ids}
-            phx-click="add"
-            phx-value-id={user.id}
-          >
-            <HStack>
-              <.user_profile
-                user={user}
-                online={LaxWeb.Presence.Live.online?(assigns, user)}
-                size={:md}
-              />
-              <Text><%= user.username %></Text>
-              <Spacer />
-              <Image systemName="plus" style="foregroundStyle(.tint);" />
-            </HStack>
-          </Button>
-        </Section>
+        <Button
+          :for={user <- @filtered_users}
+          :if={user.id not in @selected_user_ids}
+          phx-click="add"
+          phx-value-id={user.id}
+        >
+          <HStack>
+            <.user_profile
+              user={user}
+              online={LaxWeb.Presence.Live.online?(assigns, user)}
+              size={:md}
+            />
+            <Text><%= user.username %></Text>
+            <Spacer />
+            <Image systemName="plus" style="foregroundStyle(.tint);" />
+          </HStack>
+        </Button>
       </List>
 
       <VStack
@@ -76,6 +54,31 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
           phx-change="validate"
           phx-submit="submit"
         />
+      </VStack>
+
+      <VStack template="group" spacing="0" :if={MapSet.size(@selected_user_ids) > 0}>
+        <ScrollView axes="horizontal" style="background(.bar);">
+          <HStack style="padding(.horizontal); padding(.vertical, 8); buttonStyle(.bordered); buttonBorderShape(.roundedRectangle); controlSize(.small);">
+            <Button
+              :for={user <- Enum.map(@selected_user_ids, fn id -> Enum.find(@users, &(&1.id == id)) end)}
+              phx-click="remove"
+              phx-value-id={user.id}
+              style="fixedSize(horizontal: true, vertical: false);"
+            >
+              <HStack style="padding(.leading, -4);">
+                <.user_profile
+                  user={user}
+                  online={LaxWeb.Presence.Live.online?(assigns, user)}
+                  size={:xs}
+                />
+                <Text><%= user.username %></Text>
+                <Spacer />
+                <Image systemName="xmark" style="foregroundStyle(.tint);" />
+              </HStack>
+            </Button>
+          </HStack>
+        </ScrollView>
+        <Divider />
       </VStack>
     </Group>
     """

--- a/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
@@ -2,10 +2,82 @@ defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
   use LaxNative, [:render_component, format: :swiftui]
 
   import LaxWeb.DirectMessageLive.Components.SwiftUI
+  import LaxWeb.UserLive.Components.SwiftUI
+  import LaxWeb.ChatLive.Components.SwiftUI
 
   def render(assigns, _interface) do
     ~LVN"""
-    hello, world!
+    <Group
+      style={[
+        ~s[searchable(text: attr("filter"), placement: .navigationBarDrawer(displayMode: .always), prompt: "Add users")],
+        "safeAreaInset(edge: .bottom, content: :chat_form)",
+        ~s[navigationTitle("New Message")]
+      ]}
+      filter={@filter}
+      phx-change="filter"
+    >
+      <List
+        style={[
+          "listStyle(.plain)",
+          ~s[animation(.default, value: attr("selected_user_ids"))]
+        ]}
+        selected_user_ids={Enum.into(@selected_user_ids, [])}
+      >
+        <Section>
+          <Text template="header">Group</Text>
+          <Button
+            :for={user <- Enum.map(@selected_user_ids, fn id -> Enum.find(@users, &(&1.id == id)) end)}
+            phx-click="remove"
+            phx-value-id={user.id}
+          >
+            <HStack>
+              <.user_profile
+                user={user}
+                online={LaxWeb.Presence.Live.online?(assigns, user)}
+                size={:md}
+              />
+              <Text><%= user.username %></Text>
+              <Spacer />
+              <Image systemName="minus" style="foregroundStyle(.tint);" />
+            </HStack>
+          </Button>
+        </Section>
+        <Section>
+          <Text template="header">More Users</Text>
+          <Button
+            :for={user <- @filtered_users}
+            :if={user.id not in @selected_user_ids}
+            phx-click="add"
+            phx-value-id={user.id}
+          >
+            <HStack>
+              <.user_profile
+                user={user}
+                online={LaxWeb.Presence.Live.online?(assigns, user)}
+                size={:md}
+              />
+              <Text><%= user.username %></Text>
+              <Spacer />
+              <Image systemName="plus" style="foregroundStyle(.tint);" />
+            </HStack>
+          </Button>
+        </Section>
+      </List>
+
+      <VStack
+        template="chat_form"
+        spacing="0"
+        style="background(.bar);"
+      >
+        <Divider />
+        <.chat_form
+          form={@chat_form}
+          placeholder="Start a new message"
+          phx-change="validate"
+          phx-submit="submit"
+        />
+      </VStack>
+    </Group>
     """
   end
 end

--- a/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
+++ b/lib/lax_web/live/direct_message_live/new_direct_message_live.swiftui.ex
@@ -1,0 +1,11 @@
+defmodule LaxWeb.DirectMessageLive.NewDirectMessageLive.SwiftUI do
+  use LaxNative, [:render_component, format: :swiftui]
+
+  import LaxWeb.DirectMessageLive.Components.SwiftUI
+
+  def render(assigns, _interface) do
+    ~LVN"""
+    hello, world!
+    """
+  end
+end

--- a/lib/lax_web/router.ex
+++ b/lib/lax_web/router.ex
@@ -68,6 +68,7 @@ defmodule LaxWeb.Router do
       live "/chat/:id", ChatLive, :chat_selected
       live "/direct-messages", DirectMessageLive, :new
       live "/direct-messages/:id", DirectMessageLive, :show
+      live "/new-direct-message", DirectMessageLive.NewDirectMessageLive, :new
       live "/users/confirm/:token", UserConfirmationLive, :edit
       live "/users/confirm", UserConfirmationInstructionsLive, :new
     end


### PR DESCRIPTION
This refactors the `NewDirectMessage` live component to be a nested LiveView on web, and a separate route on iOS.
This works around the lack of live component support on iOS. Let me know if you have a different solution you would prefer.

The web interface should behave exactly the same.

Here is an example of the new iOS interface.

https://github.com/user-attachments/assets/3d8a5d5f-9675-457f-8db4-38bdba505325