### PR TITLE
Add notification linking and grouping

### DIFF
--- a/lib/lax/messages.ex
+++ b/lib/lax/messages.ex
@@ -97,7 +97,8 @@ defmodule Lax.Messages do
                     "body" => message.text
                   },
                   "thread-id" => channel.id
-                }
+                },
+                "navigate" => channel.id
               })
             Pigeon.APNS.push(notification)
           end)

--- a/lib/lax/messages.ex
+++ b/lib/lax/messages.ex
@@ -76,7 +76,7 @@ defmodule Lax.Messages do
               nil
             users ->
               users
-              |> Enum.reduce({"To You", length(users) - 2}, fn
+              |> Enum.reduce({"To You", length(users)}, fn
                 user, {"", l} ->
                   {"@#{user.username}", l - 1}
                 user, {acc, 1} ->

--- a/lib/lax/messages.ex
+++ b/lib/lax/messages.ex
@@ -65,16 +65,41 @@ defmodule Lax.Messages do
     with pid when pid != nil <- GenServer.whereis(:apns_default),
          :direct_message <- channel.type do
       users = Repo.preload(channel, :users).users
+      sender = message.sent_by_user
+      title = "@#{sender.username}"
 
       for user <- users, user.id != message.sent_by_user_id do
         for device_token <- user.apns_device_token do
           bundle_id = "com.example.Lax"
-          message_body = "@#{message.sent_by_user.username}: #{message.text}"
+          subtitle = case Enum.filter(users, &(&1 != user and &1 != sender)) do
+            [] ->
+              nil
+            users ->
+              users
+              |> Enum.reduce({"To You", length(users) - 2}, fn
+                user, {"", l} ->
+                  {"@#{user.username}", l - 1}
+                user, {acc, 1} ->
+                  {"#{acc} & @#{user.username}", 0}
+                user, {acc, l} ->
+                  {"#{acc}, @#{user.username}", l - 1}
+              end)
+              |> elem(0)
+          end
 
           Task.Supervisor.start_child(Lax.PigeonSupervisor, fn ->
-            message_body
-            |> Pigeon.APNS.Notification.new(device_token, bundle_id)
-            |> Pigeon.APNS.push()
+            notification = Pigeon.APNS.Notification.new("", device_token, bundle_id)
+              |> Pigeon.APNS.Notification.put_custom(%{
+                "aps" => %{
+                  "alert" => %{
+                    "title" => title,
+                    "subtitle" => subtitle,
+                    "body" => message.text
+                  },
+                  "thread-id" => channel.id
+                }
+              })
+            Pigeon.APNS.push(notification)
           end)
         end
       end

--- a/lib/lax/messages.ex
+++ b/lib/lax/messages.ex
@@ -71,7 +71,7 @@ defmodule Lax.Messages do
       for user <- users, user.id != message.sent_by_user_id do
         for device_token <- user.apns_device_token do
           bundle_id = "com.example.Lax"
-          subtitle = case Enum.filter(users, &(&1 != user and &1 != sender)) do
+          subtitle = case Enum.filter(users, &(&1.id != user.id and &1.id != sender.id)) do
             [] ->
               nil
             users ->

--- a/lib/lax_web/live/chat_live.ex
+++ b/lib/lax_web/live/chat_live.ex
@@ -221,6 +221,10 @@ defmodule LaxWeb.ChatLive do
     {:noreply, assign(socket, :current_user, user)}
   end
 
+  def handle_event("swiftui_launch_notification", %{ "id" => id, "replace" => replace }, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/chat/#{id}", replace: replace)}
+  end
+
   def handle_event("swiftui_register_apns" = event, params, socket) do
     {:noreply, push_event(socket, event, params)}
   end

--- a/lib/lax_web/live/chat_live.swiftui.ex
+++ b/lib/lax_web/live/chat_live.swiftui.ex
@@ -110,6 +110,8 @@ defmodule LaxWeb.ChatLive.SwiftUI do
 
   def render(%{live_action: :chat} = assigns, _interface) do
     ~LVN"""
+    <NotificationLaunchObserver onReceive="swiftui_launch_notification" />
+
     <.header>
       Workspace
       <:actions placement="primaryAction">
@@ -189,6 +191,8 @@ defmodule LaxWeb.ChatLive.SwiftUI do
 
   def render(%{live_action: :chat_selected} = assigns, _interface) do
     ~LVN"""
+    <NotificationLaunchObserver onReceive="swiftui_launch_notification" replace />
+
     <.chat_header channel={@chat.current_channel} users_fun={&Chat.direct_message_users(@chat, &1)} />
 
     <.user_profile_sidebar

--- a/native/swiftui/Lax.xcodeproj/project.pbxproj
+++ b/native/swiftui/Lax.xcodeproj/project.pbxproj
@@ -497,7 +497,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/liveview-native/liveview-native-live-form";
 			requirement = {
-				branch = "addons-macro";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/native/swiftui/Lax.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/native/swiftui/Lax.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/liveview-native/liveview-client-swiftui",
       "state" : {
         "branch" : "main",
-        "revision" : "05d1f6256449c3f53fc60fcf17bbbae870d9b02a"
+        "revision" : "1f9bd5bf61cbce49cfce45022b7f44ad8bc48bc5"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/liveview-native/liveview-native-live-form",
       "state" : {
-        "branch" : "addons-macro",
-        "revision" : "d2caa2d156bdaae6da49aeae176358c192d76892"
+        "branch" : "main",
+        "revision" : "be71b9decab800c2f7c70c2e83ab712487ce9705"
       }
     },
     {

--- a/native/swiftui/Lax/ContentView.swift
+++ b/native/swiftui/Lax/ContentView.swift
@@ -5,17 +5,13 @@
 
 import SwiftUI
 import LiveViewNative
-import LiveViewNativeLiveForm
 
 struct ContentView: View {
-    @StateObject private var session = LiveSessionCoordinator(
-        .automatic(
-            development: .localhost(path: "/"),
-            // development: URL(string: "https://lax.ngrok.io")!,
-            production: URL(string: "https://lax.fly.dev")!
-        ),
-        customRegistryType: LaxRegistry.self
-    )
+    @ObservedObject var session: LiveSessionCoordinator<LaxRegistry>
+    
+    init(session: LiveSessionCoordinator<LaxRegistry>) {
+        self._session = .init(wrappedValue: session)
+    }
     
     var body: some View {
         LiveView(registry: LaxRegistry.self, session: session) {
@@ -31,10 +27,4 @@ struct ContentView: View {
         }
         .liveAPNSHandler(session: session)
     }
-}
-
-struct LaxRegistry: AggregateRegistry {
-    #Registries<
-        Addons.LiveForm<Self>
-    >
 }


### PR DESCRIPTION
* Push notifications open their channel when tapped
* Notifications are not shown when the channel is already open
* Notification text includes the names of the recipients as a subtitle (if the chat includes more than 2 participants)
* Notifications are grouped by channel in the notification center

Here's an example of the deep linking:

https://github.com/user-attachments/assets/1de41436-b492-418b-9c42-f595db561234

